### PR TITLE
Fix Windows Release Bluetooth and add publishing pipeline

### DIFF
--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -1,0 +1,86 @@
+name: Windows release
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up .NET 8
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.0.x"
+
+      - name: Restore
+        run: dotnet restore .\Edi.sln --nologo
+
+      - name: Test
+        run: >-
+          dotnet test .\Edi.Core.Tests\Edi.Core.Tests.csproj
+          --configuration Release
+          --framework net8.0
+          --no-restore
+          --nologo
+
+      - name: Publish self-contained Windows build
+        shell: pwsh
+        run: >-
+          .\scripts\Publish-Windows.ps1
+          -Configuration Release
+          -OutputDirectory "${{ runner.temp }}\Edi-win-x64"
+
+      - name: Package release
+        shell: pwsh
+        run: |
+          $zipPath = Join-Path "${{ runner.temp }}" "Edi-win-x64.zip"
+          Compress-Archive `
+            -Path "${{ runner.temp }}\Edi-win-x64\*" `
+            -DestinationPath $zipPath `
+            -CompressionLevel Optimal
+          $hash = (Get-FileHash $zipPath -Algorithm SHA256).Hash.ToLowerInvariant()
+          "$hash  Edi-win-x64.zip" |
+            Set-Content `
+              -Path "${{ runner.temp }}\Edi-win-x64.sha256" `
+              -Encoding ascii
+
+      - name: Upload workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Edi-win-x64
+          path: |
+            ${{ runner.temp }}\Edi-win-x64.zip
+            ${{ runner.temp }}\Edi-win-x64.sha256
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Attach files to GitHub Release
+        if: startsWith(github.ref, 'refs/tags/')
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $tag = "${{ github.ref_name }}"
+          $zipPath = Join-Path "${{ runner.temp }}" "Edi-win-x64.zip"
+          $hashPath = Join-Path "${{ runner.temp }}" "Edi-win-x64.sha256"
+          gh release view $tag *> $null
+          if ($LASTEXITCODE -eq 0) {
+            gh release upload $tag $zipPath $hashPath --clobber
+          } else {
+            gh release create `
+              $tag `
+              $zipPath `
+              $hashPath `
+              --generate-notes `
+              --title "EDI $tag"
+          }

--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -2,7 +2,12 @@ name: Windows release
 
 on:
   workflow_dispatch:
+  pull_request:
+    branches:
+      - "master"
   push:
+    branches:
+      - "master"
     tags:
       - "v*"
 

--- a/.gitignore
+++ b/.gitignore
@@ -185,6 +185,7 @@ publish/
 # Note: Comment the next line if you want to checkin your web deploy settings,
 # but database connection strings (with potential passwords) will be unencrypted
 *.pubxml
+!Edi.Wpf/Properties/PublishProfiles/FolderProfile.pubxml
 *.publishproj
 
 # Microsoft Azure Web App publish settings. Comment the next line if you want to

--- a/Edi.Wpf/Edi.Wpf.csproj
+++ b/Edi.Wpf/Edi.Wpf.csproj
@@ -3,11 +3,13 @@
   <PropertyGroup>
 	<OutputType>WinExe</OutputType>
 	<TargetFramework>net8.0-windows10.0.19041</TargetFramework>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
 	<Nullable>enable</Nullable>
 	<UseWPF>true</UseWPF>
     <ImplicitUsings>enable</ImplicitUsings>
     <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>true</SelfContained>
+    <PublishTrimmed>false</PublishTrimmed>
     <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
     <AssemblyName>Edi</AssemblyName>
 	  <Version>1.0.2</Version>

--- a/Edi.Wpf/Properties/PublishProfiles/FolderProfile.pubxml
+++ b/Edi.Wpf/Properties/PublishProfiles/FolderProfile.pubxml
@@ -1,0 +1,25 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project>
+  <PropertyGroup>
+    <DeleteExistingFiles>true</DeleteExistingFiles>
+    <ExcludeApp_Data>false</ExcludeApp_Data>
+    <LaunchSiteAfterPublish>true</LaunchSiteAfterPublish>
+    <LastUsedBuildConfiguration>Release</LastUsedBuildConfiguration>
+    <LastUsedPlatform>Any CPU</LastUsedPlatform>
+    <PublishProvider>FileSystem</PublishProvider>
+    <PublishUrl>bin\Release\net8.0-windows10.0.19041\win-x64\publish\</PublishUrl>
+    <WebPublishMethod>FileSystem</WebPublishMethod>
+    <_TargetId>Folder</_TargetId>
+    <SiteUrlToLaunchAfterPublish />
+    <TargetFramework>net8.0-windows10.0.19041</TargetFramework>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <PublishSingleFile>true</PublishSingleFile>
+    <PublishTrimmed>false</PublishTrimmed>
+    <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
+    <ProjectGuid>62d19d9e-ef34-4145-a228-02eb529f2d90</ProjectGuid>
+    <SelfContained>true</SelfContained>
+  </PropertyGroup>
+</Project>

--- a/README.md
+++ b/README.md
@@ -7,6 +7,24 @@ EDI operates as an independent service that:
 - Exposes a REST API for complete control of device playback and settings
 - Handles all device communication, funscripts and synchronization
 - Can be integrated with any game engine or framework that supports HTTP requests
+
+### Download and requirements
+
+Download the latest self-contained Windows build from
+[GitHub Releases](https://github.com/NoGRo/Edi/releases/latest). Extract the ZIP and run
+`Edi.exe`.
+
+The published `Edi-win-x64.zip` requires:
+
+- Windows 10/11 x64 (build 19041 or newer).
+- A Bluetooth LE adapter enabled in Windows for local Handy Bluetooth connections.
+
+The ZIP is self-contained, so users do not need to install .NET separately. Developers who
+intentionally make a framework-dependent build can install the
+[.NET 8 Desktop Runtime (x64)](https://dotnet.microsoft.com/en-us/download/dotnet/8.0/runtime?cid=getdotnetcore&runtime=desktop&os=windows&arch=x64)
+and the
+[ASP.NET Core Runtime 8 (x64)](https://dotnet.microsoft.com/en-us/download/dotnet/8.0/runtime?cid=getdotnetcore&runtime=aspnetcore&os=windows&arch=x64).
+
 ---
 
 ### Why Use EDI?

--- a/scripts/Publish-Windows.ps1
+++ b/scripts/Publish-Windows.ps1
@@ -1,0 +1,37 @@
+param(
+    [string]$OutputDirectory = "",
+    [ValidateSet("Debug", "Release")]
+    [string]$Configuration = "Release"
+)
+
+$ErrorActionPreference = "Stop"
+
+$repositoryRoot = Split-Path -Parent $PSScriptRoot
+$projectPath = Join-Path $repositoryRoot "Edi.Wpf\Edi.Wpf.csproj"
+
+if ([string]::IsNullOrWhiteSpace($OutputDirectory)) {
+    $OutputDirectory = Join-Path `
+        $repositoryRoot `
+        "artifacts\Edi-win-x64"
+}
+
+$OutputDirectory = [System.IO.Path]::GetFullPath($OutputDirectory)
+
+dotnet publish $projectPath `
+    --configuration $Configuration `
+    --framework net8.0-windows10.0.19041 `
+    --runtime win-x64 `
+    --self-contained true `
+    --output $OutputDirectory `
+    -p:PublishSingleFile=true `
+    -p:PublishTrimmed=false `
+    -p:IncludeNativeLibrariesForSelfExtract=true `
+    -p:DebugSymbols=false `
+    -p:DebugType=None `
+    --nologo
+
+if ($LASTEXITCODE -ne 0) {
+    throw "Windows publish failed with exit code $LASTEXITCODE."
+}
+
+Write-Host "EDI Windows build published to $OutputDirectory"


### PR DESCRIPTION
## What changed

- Correct the WPF publish target to `net8.0-windows10.0.19041` / `win-x64` so Release builds select EDI's native Windows GATT transport.
- Publish a self-contained, untrimmed single-file Windows executable.
- Add a reusable local PowerShell publishing script and a GitHub Actions workflow.
- Upload a ZIP plus SHA-256 checksum for manual workflow runs; `v*` tags also create or update a GitHub Release.
- Document the GitHub Releases download and Windows/Bluetooth requirements. The self-contained ZIP does not require users to install .NET runtimes.

## Root cause

The previous Visual Studio folder profile overrode the project target with `net8.0-windows7.0`. That made the multi-targeted `Edi.Core` project resolve to generic `net8.0`, selecting the fallback Bluetooth implementation instead of the native Windows GATT implementation used by Debug builds.

## Validation

- `dotnet test Edi.Core.Tests/Edi.Core.Tests.csproj --configuration Release --framework net8.0`: 127 passed.
- `dotnet build Edi.sln --configuration Debug --nologo --disable-build-servers --maxcpucount:1`: succeeded with 0 errors.
- Local self-contained Release publish selected `Edi.Core` target `net8.0-windows10.0.19041`.
- The published Release was run against live hardware and detected `The Handy 2 Pro (BLE)` as Ready.
- Generated `Edi-win-x64.zip` and SHA-256 checksum successfully.